### PR TITLE
Make `explicitFullwidthChars` work with long regular expressions.

### DIFF
--- a/src/extension.ts
+++ b/src/extension.ts
@@ -35,7 +35,7 @@ export function activate(context: vscode.ExtensionContext) {
         settings.common.centerAlignedHeader = config.get('common.centerAlignedHeader', false);
         settings.common.explicitFullwidthChars = []
         let chars = config.get('common.explicitFullwidthChars', []).filter(function (elem, i, self) {
-            return ((self.indexOf(elem) === i ) && (elem.length == 1));
+            return (self.indexOf(elem) === i );
         });
         chars.forEach((char, i) => {
             settings.common.explicitFullwidthChars.push(new RegExp(char, 'g'));


### PR DESCRIPTION
['℃'の文字を含む場合の動作について · Issue #9 · shuGH/vscode-table-formatter](https://github.com/shuGH/vscode-table-formatter/issues/9)
上記 issue に関連してですが、
①②... αΒ... 複数の文字に対して範囲を指定したいです。
現在のコードでは長さを 1 に制限しているので `explicitFullwidthChars` には1文字ずつしか指定できません。
長さ制限を取り払うことで複雑な正規表現をかけるようになりますがいかがでしょうか。

```
    "tableformatter.common.explicitFullwidthChars": [
        "[①-⑨]",
        "[α-ω]",
    ],
```
