### PR TITLE
Fix Build Process

### DIFF
--- a/package.json
+++ b/package.json
@@ -116,7 +116,7 @@
         "trim": "0.0.1"
     },
     "devDependencies": {
-        "typescript": "^2.0.3",
+        "typescript": "^3.9.10",
         "vscode": "^1.0.0",
         "mocha": "^2.3.3",
         "@types/node": "^6.0.40",


### PR DESCRIPTION
Building the extension using `vsce package` is currently not possible.
The `@types/node`-dependency contains expressions which require at least `typescript` v3 in order to be interpreted and compiled correctly.

Changes made in this PR will update `typescript` to v3 making this package able to build again.